### PR TITLE
Always add GrepDef command and shortcut

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,2 +1,0 @@
-command! -nargs=* -complete=file GrepDef :call g:GrepDef(<q-args>)
-nnoremap <Leader>d :GrepDef <cword><CR>

--- a/ftplugin/php.vim
+++ b/ftplugin/php.vim
@@ -1,2 +1,0 @@
-command! -nargs=* -complete=file GrepDef :call g:GrepDef(<q-args>)
-nnoremap <Leader>d :GrepDef <cword><CR>

--- a/ftplugin/typescript.vim
+++ b/ftplugin/typescript.vim
@@ -1,2 +1,0 @@
-command! -nargs=* -complete=file GrepDef :call g:GrepDef(<q-args>)
-nnoremap <Leader>d :GrepDef <cword><CR>

--- a/plugin/grepdef.vim
+++ b/plugin/grepdef.vim
@@ -31,3 +31,6 @@ function! g:GrepDef(args)
   cgete grepdef_output
   copen
 endfunction
+
+command! -nargs=* -complete=file GrepDef :call g:GrepDef(<q-args>)
+nnoremap <Leader>d :GrepDef <cword><CR>


### PR DESCRIPTION
Previously the `GrepDef` command was only added when filetype detection found a JS, TS, or PHP file. However, when first opening vim inside a directory (and no file is open), it's sometimes desirable to immediately run `:GrepDef`. Filetype is not needed because `grepdef` uses filetype detection anyway.